### PR TITLE
Fixed syntax error when having multiple entries in the Format dictionary

### DIFF
--- a/AniListNet.Tests/SearchTests.cs
+++ b/AniListNet.Tests/SearchTests.cs
@@ -21,6 +21,24 @@ public class SearchTests
     }
 
     [Test]
+    public async Task SearchAnimeMediaFormatTest()
+    {
+        var results = await TestObjects.AniClient.SearchMediaAsync(new SearchMediaFilter
+        {
+            Query = "demon slayer",
+            Sort = MediaSort.Popularity,
+            Type = MediaType.Anime,
+            Format = new Dictionary<MediaFormat, bool>{
+                {MediaFormat.TV, true},
+                {MediaFormat.TVShort, true},
+                {MediaFormat.Special, true},
+            }
+        }, new AniPaginationOptions(1, 5));
+        Console.WriteLine(ObjectDumper.Dump(results));
+        Assert.IsTrue(results.Data.Any(item => item.Type == MediaType.Anime));
+    }
+
+    [Test]
     public async Task SearchMangaMediaTest()
     {
         var results = await TestObjects.AniClient.SearchMediaAsync(new SearchMediaFilter

--- a/AniListNet.Tests/SearchTests.cs
+++ b/AniListNet.Tests/SearchTests.cs
@@ -21,24 +21,6 @@ public class SearchTests
     }
 
     [Test]
-    public async Task SearchMediaFormatTest()
-    {
-        var results = await TestObjects.AniClient.SearchMediaAsync(new SearchMediaFilter
-        {
-            Query = "demon slayer",
-            Sort = MediaSort.Popularity,
-            Type = MediaType.Anime,
-            Format = new Dictionary<MediaFormat, bool>{
-                {MediaFormat.TV, true},
-                {MediaFormat.TVShort, true},
-                {MediaFormat.Special, true},
-            }
-        }, new AniPaginationOptions(1, 5));
-        Console.WriteLine(ObjectDumper.Dump(results));
-        Assert.IsTrue(results.Data.Any(item => item.Type == MediaType.Anime));
-    }
-
-    [Test]
     public async Task SearchMangaMediaTest()
     {
         var results = await TestObjects.AniClient.SearchMediaAsync(new SearchMediaFilter
@@ -49,6 +31,31 @@ public class SearchTests
         }, new AniPaginationOptions(1, 5));
         Console.WriteLine(ObjectDumper.Dump(results));
         Assert.IsTrue(results.Data.Any(item => item.Type == MediaType.Manga));
+    }
+
+    [Test]
+    public async Task SearchMediaByFormatTest()
+    {
+        var results = await TestObjects.AniClient.SearchMediaAsync(new SearchMediaFilter
+        {
+            Query = "demon slayer",
+            Sort = MediaSort.Popularity,
+            Type = MediaType.Anime,
+            Format = new Dictionary<MediaFormat, bool>
+            {
+                { MediaFormat.TV, true },
+                { MediaFormat.TVShort, true },
+                { MediaFormat.Special, true },
+                { MediaFormat.Movie, false }
+            }
+        }, new AniPaginationOptions(1, 5));
+        Console.WriteLine(ObjectDumper.Dump(results));
+        Assert.IsTrue(results.Data.Any(item => item.Format is
+            (MediaFormat.TV or
+            MediaFormat.TVShort or
+            MediaFormat.Special) and not
+            MediaFormat.Movie
+        ));
     }
 
     [Test]

--- a/AniListNet.Tests/SearchTests.cs
+++ b/AniListNet.Tests/SearchTests.cs
@@ -21,7 +21,7 @@ public class SearchTests
     }
 
     [Test]
-    public async Task SearchAnimeMediaFormatTest()
+    public async Task SearchMediaFormatTest()
     {
         var results = await TestObjects.AniClient.SearchMediaAsync(new SearchMediaFilter
         {

--- a/AniListNet/Helpers/GqlParser.cs
+++ b/AniListNet/Helpers/GqlParser.cs
@@ -95,7 +95,7 @@ internal static class GqlParser
                 stringBuilder.Append('[');
                 foreach (var item in enumerable)
                 {
-                    stringBuilder.Append(stringBuilder.Length > 1 ? string.Empty : ",");
+                    stringBuilder.Append(stringBuilder.Length <= 1 ? string.Empty : ",");
                     stringBuilder.Append(ParseObjectString(item));
                 }
                 stringBuilder.Append(']');


### PR DESCRIPTION
This pull request fixes an issue with the syntax formatting

`Field "media" argument "format_in" requires type MediaFormat, found TVTV_SHORTSPECIAL.`

Added a test as well to prove that it works.