### PR TITLE
Setting MediaEntryStatus in MediaEntryList to allow null values

### DIFF
--- a/AniListNet/Objects/Media/MediaEntryList.cs
+++ b/AniListNet/Objects/Media/MediaEntryList.cs
@@ -8,6 +8,6 @@ public class MediaEntryList
     [JsonProperty("entries")] public MediaEntry[] Entries { get; private set; }
     [JsonProperty("name")] public string Name { get; private set; }
     [JsonProperty("isCustomList")] public bool IsCustomList { get; private set; }
-    [JsonProperty("status")] public MediaEntryStatus Status { get; private set; }
+    [JsonProperty("status")] public MediaEntryStatus? Status { get; private set; }
 
 }


### PR DESCRIPTION
Reason for the PR:
When user adds custom list it's status becomes null, or rather is not in the enum. Because of that `#GetUserEntryCollectionAsync()` throws and error that it cannot be parsed.

To test that can be null click [here](https://anilist.co/graphiql?query=%7B%0A%20%20MediaListCollection(userId%3A%20165049%2C%20type%3A%20ANIME)%20%7B%0A%20%20%20%20lists%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20isCustomList%0A%20%20%20%20%20%20status%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A)

To reproduce simply:
```csharp
await _client.GetUserEntryCollectionAsync(165049, MediaType.Anime, new AniPaginationOptions(1, 500))
```

No tests were written as no core changes were made