### PR TITLE
Throw non Unauthorized exceptions in TryAuthenticateAsync

### DIFF
--- a/src/AniListNet/AniClient.cs
+++ b/src/AniListNet/AniClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Headers;
+﻿using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using AniListNet.Helpers;
 using Newtonsoft.Json.Linq;
@@ -22,8 +23,13 @@ public partial class AniClient
             _ = await GetAuthenticatedUserAsync();
             IsAuthenticated = true;
         }
-        catch
+        catch (AniException aniException)
         {
+            if (aniException.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                throw;
+            }
+            
             _client.DefaultRequestHeaders.Authorization = null;
             IsAuthenticated = false;
         }
@@ -50,7 +56,8 @@ public partial class AniClient
             (
                 responseJson["errors"]!.First!["message"]!.ToString(),
                 bodyText!,
-                responseText
+                responseText,
+                response.StatusCode
             );
 
         // Check rate limit

--- a/src/AniListNet/AniException.cs
+++ b/src/AniListNet/AniException.cs
@@ -1,13 +1,18 @@
-﻿namespace AniListNet;
+﻿using System.Net;
+
+namespace AniListNet;
 
 public class AniException : Exception
 {
     public string ActualRequestBody { get; }
     public string ActualResponseBody { get; }
+    
+    public HttpStatusCode StatusCode { get; }
 
-    internal AniException(string message, string actualRequestBody, string actualResponseBody) : base(message)
+    internal AniException(string message, string actualRequestBody, string actualResponseBody, HttpStatusCode statusCode) : base(message)
     {
         ActualRequestBody = actualRequestBody;
         ActualResponseBody = actualResponseBody;
+        StatusCode = statusCode;
     }
 }


### PR DESCRIPTION
The TryAuthenticateAsync method can return false positives when the request fails for reasons other than an Unauthorized response—such as hitting a rate limit. In such cases, the consuming application may incorrectly interpret the response as an invalid token.

This PR changes the behaviour so that these exceptions are re-thrown, allowing the consuming application to handle them manually.

This issue is particularly noticeable when making requests for multiple tokens/accounts from the same IP address, where combined rate limits may be exceeded more quickly than individual rate limit headers suggest.